### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- add version and pname
 - add build to flake
-
-### Other
-
-- fix CHANGELOG
 
 ## [0.2.0](https://github.com/bmblb3/kittylitters/compare/v0.1.0...v0.2.0) - 2025-09-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/bmblb3/kittylitters/compare/v0.2.0...v0.2.1) - 2025-10-01
+
+### Added
+
+- add version and pname
+- add build to flake
+
+### Other
+
+- fix CHANGELOG
+
 ## [0.2.0](https://github.com/bmblb3/kittylitters/compare/v0.1.0...v0.2.0) - 2025-09-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "kittylitters"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "color-eyre",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kittylitters"
-version = "0.2.0"
+version = "0.2.1"
 description = "A simple app to sync a yaml file which describes tabs and windows to the currently open kitty session"
 repository = "https://github.com/bmblb3/kittylitters"
 license = "MIT OR Apache-2.0"

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
         packages = {
           default = pkgs.rustPlatform.buildRustPackage rec {
             pname = "kittylitters";
-            version = "0.2.0";
+            version = "0.2.1";
             name = "${pname}-${version}";
             src = ./.;
             cargoLock = {


### PR DESCRIPTION



## 🤖 New release

* `kittylitters`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/bmblb3/kittylitters/compare/v0.2.0...v0.2.1) - 2025-10-01

### Added

- add version and pname
- add build to flake

### Other

- fix CHANGELOG
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).